### PR TITLE
Refactor configuration and setup, as well as individual command execution

### DIFF
--- a/dashboards-using-metrics.rb
+++ b/dashboards-using-metrics.rb
@@ -4,6 +4,9 @@ require_relative 'command'
 
 class DashboardsUsingMetrics < Command
   def parse_args(options, parser)
+    parser.banner = "Usage: #{$0} [options] <metric>\n"+
+                    "Example: #{$0} 'system.load.1'"
+
     options[:is_regex] = false
 
     parser.on('-r', '--[no-]regex', 'Input is a regular expression (don\'t quote)') do |v|
@@ -117,14 +120,14 @@ class DashboardsUsingMetrics < Command
   end
 
   def run()
-    raise ArgumentError.new("You must specify a metric name!") unless @args.length > 0
+    super do
+      raise ArgumentError.new("You must specify a metric name!") unless @args.length > 0
+    end
+
     metric = @args[0]
 
     print_dashboard_matches(metric)
     print_screenboard_matches(metric)
-  rescue ArgumentError => e
-    puts @parser
-    puts e.to_s
   end
 end
 

--- a/get-downtime.rb
+++ b/get-downtime.rb
@@ -5,11 +5,19 @@ require_relative 'command'
 class GetDowntime < Command
 
   def run()
-    id = ARGV[0] || raise("You must specify an ID!")
-    @logger.info("Looking for downtime: '#{id}'")
-    result = @dog_client.get_downtime(id)
+    super do
+      raise ArgumentError.new("You must specify an ID!") unless ARGV[0]
+    end
+    id = ARGV[0]
 
-    puts(result)
+    @error_logger.info("Looking for downtime: '#{id}'")
+    status, result = @dog_client.get_downtime(id)
+
+    if status = 200
+      puts(result)
+    else
+      @error_logger.error(result)
+    end
   end
 end
 

--- a/monitors-using-metrics.rb
+++ b/monitors-using-metrics.rb
@@ -4,6 +4,9 @@ require_relative 'command'
 
 class MonitorsUsingMetrics < Command
   def parse_args(options, parser)
+    parser.banner = "Usage: #{$0} [options] <metric>\n"+
+                    "Example: #{$0} 'system.load.1'"
+
     options[:is_regex] = false
 
     parser.on('-r', '--[no-]regex', 'Input is a regular expression (don\'t quote)') do |v|
@@ -34,13 +37,13 @@ class MonitorsUsingMetrics < Command
   end
 
   def run()
-    raise ArgumentError.new("You must specify a metric name!") unless @args.length > 0
+    super do
+      raise ArgumentError.new("You must specify a metric name!") unless @args.length > 0
+    end
+
     metric = @args[0]
 
     print_monitor_matches(metric)
-  rescue ArgumentError => e
-    puts @parser
-    puts e.to_s
   end
 end
 

--- a/query-metrics.rb
+++ b/query-metrics.rb
@@ -7,15 +7,22 @@ require_relative 'command'
 class QueryMetrics < Command
 
   def parse_args(options, parser)
+    parser.banner = "Usage: #{$0} [options] <query>\n"+
+                    "Example: #{$0} 'avg:system.load.1{*}'"
+
     options[:from] = Chronic.parse('30 minutes ago')
     options[:to] = Chronic.parse('now')
 
-    parser.on('-f', '--from', 'From date, which can be anything Chronic can parse (https://github.com/mojombo/chronic). Defaults to 30m ago') do |f|
-      options[:from] = Chronic.parse(f)
+    parser.on('-f SPEC', '--from SPEC', 'From date, which can be anything Chronic can parse (https://github.com/mojombo/chronic). Defaults to 30m ago') do |f|
+      parsed = Chronic.parse(f)
+      raise ArgumentError.new("Invalid time specification: '#{f}'") if parsed.nil?
+      options[:from] = parsed
     end
 
-    parser.on('-t', '--to', 'To date, which can be anything Chronic can parse (https://github.com/mojombo/chronic). Defaults to now') do |t|
-      options[:to] = Chronic.parse(f)
+    parser.on('-t SPEC', '--to SPEC', 'To date, which can be anything Chronic can parse (https://github.com/mojombo/chronic). Defaults to now') do |t|
+      parsed = Chronic.parse(f)
+      raise ArgumentError.new("Invalid time specification: '#{f}'") if parsed.nil?
+      options[:to] = parsed
     end
 
     parser.on('-j', '--json', 'Output JSON instead of text') do |j|
@@ -24,13 +31,22 @@ class QueryMetrics < Command
   end
 
   def run()
-    @args.length > 0 || raise("You must specify a query!")
+    super do
+      raise ArgumentError.new("You must specify a query!") unless @args.length > 0
+    end
+
     query = @args[0]
     resp = @dog_client.get_points(query, @options[:from].to_time.to_i, @options[:to].to_time.to_i)[1]
+    series = resp.fetch('series', [])
+
+    # unfortunately, ruby's logger doesn't switch between stderr/stdout depending on severity,
+    # and for the other commands it writes to stdout, so we can't use it for this warning
+    @error_logger.warn("No results for query") if series.empty?
+
     if @options[:json]
       puts(resp.to_json)
     else
-      for s in resp['series']
+      for s in series
         puts(s['metric'])
         for p in s['pointlist']
           puts("\t#{Time.at(p[0].to_i / 1000).to_datetime}, #{p[1]}")


### PR DESCRIPTION
Sorry, this maybe got a little out of hand. It started out as adding more useful error messages to your PR, but I ran into a number of things that could hopefully be better. The interleaving of run/super/blocks is not great, so probably it should take a top-down form in the future at some point.

- Surfaces a clear error for failures, allows sub-commands to perform extra validation
- Adds @error_logger, which logs colored/formatted errors to stderr so they don't
  interfere with pipes
- Adds a warning to query-metrics when it receives an empty response (often the result
  of an invalid query or a metric that doesn't exist)
- Fixes query-metrics parser arguments for from/to, adds an error and help dump when
  invalid input is given for these
- Fixes parser specifications for switches that require an argument

R? @cory-stripe 