### PR TITLE
Fix parsing of --to option

### DIFF
--- a/query-metrics.rb
+++ b/query-metrics.rb
@@ -20,8 +20,8 @@ class QueryMetrics < Command
     end
 
     parser.on('-t SPEC', '--to SPEC', 'To date, which can be anything Chronic can parse (https://github.com/mojombo/chronic). Defaults to now') do |t|
-      parsed = Chronic.parse(f)
-      raise ArgumentError.new("Invalid time specification: '#{f}'") if parsed.nil?
+      parsed = Chronic.parse(t)
+      raise ArgumentError.new("Invalid time specification: '#{t}'") if parsed.nil?
       options[:to] = parsed
     end
 


### PR DESCRIPTION
Fixes the following:

    $ ./query-metrics.rb --from '3 pm' --to '3:10 pm' 'system.disk.total{*}'
    E, [15:04:31] : undefined local variable or method `f' for #<QueryMetrics:0x007fd2689afaa0>

r? @krisreeves-stripe